### PR TITLE
Document the public index-handler interface

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+FiniteStateProjection = "069e79ea-d681-44e8-b935-95bdaf9e8f28"
 
 [compat]
 Documenter = "0.27, 1"

--- a/docs/src/indexhandlers.md
+++ b/docs/src/indexhandlers.md
@@ -2,9 +2,29 @@
 
 The task of an index handler is to provide a mapping between the system state and the way it is stored in memory, usually as a multidimensional array. The standard approach is to represent the states of a system with ``s`` reactions as an ``s``-dimensional array and have the index ``(i_1, \ldots, i_s)`` correspond to the state ``(n_1 = i_1, \ldots, n_s = i_s)``. This is implemented by the class [`DefaultIndexHandler`](@ref), which accepts an offset argument to deal with Julia's 1-based indexing (so the Julia index $(1,\ldots,1)$ corresponds to the state with no molecules).
 
-See the [internal API](@ref index_handlers_internal) on how to define your own `IndexHandler` type.
+## Extending Index Handlers
+
+To define a custom index handler, subtype [`AbstractIndexHandler`](@ref) and import
+the extension functions before adding methods:
+
+```julia
+import Base: LinearIndices, vec
+import FiniteStateProjection: build_rhs_header, getsubstitutions, pairedindices, singleindices
+```
+
+Implement `getsubstitutions`, plus array and dimension-tuple methods for
+`singleindices` and `pairedindices`. Implement `LinearIndices` and `vec` as well when
+the handler supports sparse-matrix conversions.
+Override `build_rhs_header` only when generated RHS functions need parameters arranged
+differently from the default vector form.
 
 ```@docs
+AbstractIndexHandler
 DefaultIndexHandler
 NaiveIndexHandler
+singleindices
+pairedindices
+getsubstitutions
+build_rhs_header
+Base.LinearIndices
 ```

--- a/docs/src/internal.md
+++ b/docs/src/internal.md
@@ -6,7 +6,7 @@ CurrentModule = FiniteStateProjection
 
 ## [Index Handlers](@id index_handlers_internal)
 
-### Index Handler Interface
+### Index Handler Implementations
 
 User-defined index handlers should inherit from `AbstractIndexHandler` and implement the following methods:
 
@@ -19,14 +19,6 @@ For matrix conversions they should additionally implement:
 
   - [`LinearIndices`](@ref Base.LinearIndices)
   - [`vec`](@ref Base.vec)
-
-```@docs
-singleindices
-pairedindices
-getsubstitutions
-build_rhs_header
-LinearIndices
-```
 
 ### Built-in implementations
 

--- a/src/FiniteStateProjection.jl
+++ b/src/FiniteStateProjection.jl
@@ -17,7 +17,8 @@ import Base: LinearIndices, vec
 
 RuntimeGeneratedFunctions.init(@__MODULE__)
 
-export FSPSystem, DefaultIndexHandler, SteadyState
+export AbstractIndexHandler, DefaultIndexHandler, FSPSystem, NaiveIndexHandler, SteadyState,
+    build_rhs_header, getsubstitutions, pairedindices, singleindices
 
 _unresolve1(x) = x
 _unresolve1(f::Function) = nameof(f)
@@ -54,6 +55,17 @@ function _prettify(ex; lines = false)
     return _unresolve(_flatten(ex))
 end
 
+"""
+    AbstractIndexHandler
+
+Abstract supertype for index handlers used by [`FSPSystem`](@ref).
+
+# Extension Rules
+To implement a custom handler, subtype `AbstractIndexHandler` and extend the
+documented index-handler interface described in the manual. Matrix-capable handlers
+must implement both forms of `singleindices` and `pairedindices`, `LinearIndices`, and
+`vec`; all handlers must implement `getsubstitutions`.
+"""
 abstract type AbstractIndexHandler end
 
 include("fspsystem.jl")

--- a/src/build_rhs.jl
+++ b/src/build_rhs.jl
@@ -19,9 +19,18 @@ end
 """
     build_rhs_header(sys::FSPSystem)
 
-Return initialisation code for the RHS function, unpacking the parameters
-`p` supplied by `DifferentialEquations`. The default implementation
-just unpacks parameters from `p`.
+Returns initialization code for the generated RHS function. The default implementation
+unpacks the vector parameter `p` supplied by DifferentialEquations.jl.
+
+# Arguments
+- `sys`: FSP system whose parameter ordering determines the generated code.
+
+# Returns
+- An expression evaluated at the start of the generated RHS function.
+
+# Extension Rules
+Custom index handlers with a different parameter representation may import and extend
+this function for their corresponding `FSPSystem` specialization.
 
 See also: [`unpackparams`](@ref), [`build_rhs`](@ref)
 """

--- a/src/build_rhs_ss.jl
+++ b/src/build_rhs_ss.jl
@@ -13,6 +13,10 @@ It is used as a dispatch tag by
 [`SparseArrays.SparseMatrixCSC(::FSPSystem, ::NTuple, ps, ::SteadyState)`](@ref)
 and [`SciMLBase.SteadyStateProblem(::FSPSystem, u0, p)`](@ref).
 
+# Usage
+Pass `SteadyState()` as the final argument to `SparseMatrixCSC`, or construct a
+`SteadyStateProblem` from an `FSPSystem`.
+
 # Examples
 ```julia
 julia > SteadyState()

--- a/src/fspsystem.jl
+++ b/src/fspsystem.jl
@@ -5,10 +5,17 @@ Represent a Catalyst reaction system as a finite state projection (FSP) system.
 `FSPSystem` stores the reaction system, an index handler describing the state-array
 layout, and generated rate functions used to construct ODE and steady-state problems.
 
+# Fields
+- `rs`: Underlying Catalyst reaction system.
+- `ih`: Index handler defining the FSP state-array layout.
+- `rfs`: Generated reaction-rate functions in the index-handler representation.
+
 # Arguments
 - `rs`: Catalyst reaction system without subsystems.
 - `ih`: Index handler for the FSP state array. By default,
   `DefaultIndexHandler` uses Catalyst's species order.
+
+# Keyword Arguments
 - `combinatoric_ratelaw`: Whether to use combinatoric jump rate laws.
 
 # Examples

--- a/src/indexhandlers.jl
+++ b/src/indexhandlers.jl
@@ -1,8 +1,19 @@
 """
     singleindices(idxhandler::AbstractIndexHandler, arr)
 
-Returns all indices `I` in `arr`. Defaults to CartesianIndices, but can
-be overloaded for arbitrary index handlers.
+Returns the indices of the finite state space represented by `arr`.
+
+# Arguments
+- `idxhandler`: The index handler that defines the state-space layout.
+- `arr`: Either the state array or its tuple of dimensions.
+
+# Returns
+- An iterator of Cartesian indices. The default implementation returns
+  `CartesianIndices(arr)`.
+
+# Extension Rules
+Custom index handlers must import and extend this function. Implement both the
+state-array and dimension-tuple forms when supporting matrix conversions.
 """
 singleindices(::AbstractIndexHandler, arr::AbstractArray) = CartesianIndices(arr)
 singleindices(::AbstractIndexHandler, arr::Tuple) = CartesianIndices(arr)
@@ -10,23 +21,59 @@ singleindices(::AbstractIndexHandler, arr::Tuple) = CartesianIndices(arr)
 """
     pairedindices(idxhandler::AbstractIndexHandler, arr, shift::CartesianIndex)
 
-Returns all pairs of indices `(I .- shift, I)` in `arr`.
+Returns pairs `(I .- shift, I)` for state transitions that remain within `arr`.
+
+# Arguments
+- `idxhandler`: The index handler that defines the state-space layout.
+- `arr`: Either the state array or its tuple of dimensions.
+- `shift`: The reaction stoichiometry as a Cartesian index in Catalyst species order.
+
+# Returns
+- An iterator of source and destination Cartesian-index pairs.
+
+# Extension Rules
+Custom index handlers must import and extend this function. Implement both the
+state-array and dimension-tuple forms when supporting matrix conversions.
 """
 function pairedindices end
 
 """
     getsubstitutions(idxhandler::AbstractIndexHandler, rs::ReactionSystem; state_sym::Symbol)
 
-Returns a dict of the form `S_i => f_i(state_sym)`, where each `f_i` is an expression
-for the abundance of species `S_i` in terms of the state variable `state_sym`.
+Returns a dictionary `S_i => f_i(state_sym)`, where each `f_i` computes a species
+abundance from the symbolic state variable.
+
+# Arguments
+- `idxhandler`: The index handler that defines the state-space layout.
+- `rs`: Catalyst reaction system whose species require substitutions.
+
+# Keyword Arguments
+- `state_sym`: Symbol naming the generated RHS state variable.
+
+# Returns
+- A dictionary mapping each Catalyst species to a symbolic abundance expression.
+
+# Extension Rules
+Custom index handlers must import and extend this function.
 """
 function getsubstitutions end
 
 """
     vec(idxhandler::AbstractIndexHandler, arr)
 
-Converts the right-hand side defining the solution of the CME into a
-one-dimensional vector to which a matrix can be applied.
+Converts the CME state array into the vector ordering used by sparse-matrix
+representations.
+
+# Arguments
+- `idxhandler`: The index handler that defines the vector ordering.
+- `arr`: State array to flatten.
+
+# Returns
+- A one-dimensional state vector compatible with [`LinearIndices`](@ref Base.LinearIndices).
+
+# Extension Rules
+Custom index handlers that support matrix conversions must import and extend this
+`Base` function.
 
 See also: [`LinearIndices`](@ref Base.LinearIndices)
 """
@@ -35,13 +82,24 @@ function vec end
 """
     LinearIndices(idxhandler::AbstractIndexHandler, arr)
 
-Returns an object `lind` which converts indices returned from [`singleindices`](@ref)
-and [`pairedindices`](@ref) to linear indices compatible with [`vec`](@ref Base.vec)
-via `lind[idx_cart] = idx_lin`. The indices are related via
+Returns an object `lind` converting the Cartesian indices produced by
+[`singleindices`](@ref) and [`pairedindices`](@ref) to the linear indices of
+[`vec`](@ref Base.vec). The required invariant is
 
 ```julia
 arr[idx_cart] == vec(idxhandler, arr)[idx_lin]
 ```
+
+# Arguments
+- `idxhandler`: The index handler that defines the vector ordering.
+- `arr`: Either the state array or its tuple of dimensions.
+
+# Returns
+- An indexable object mapping Cartesian indices to vector positions.
+
+# Extension Rules
+Custom index handlers that support matrix conversions must import and extend this
+`Base` function, preserving the documented indexing invariant.
 
 See also: [`vec`](@ref Base.vec)
 """
@@ -53,9 +111,14 @@ function LinearIndices end
     DefaultIndexHandler{N}()
     DefaultIndexHandler{N}(offset, perm)
 
-Default index handler for an FSP system with `N` species. It represents the state
-as an `N`-dimensional array, maps a molecule count of zero to `offset`, and uses
-`perm` to map state-array dimensions to Catalyst's species order.
+Default index handler for an FSP system with `N` species.
+
+# Fields
+- `offset`: Julia index corresponding to a molecular count of zero.
+- `perm`: Mapping from state-array dimensions to Catalyst species order.
+
+It represents the state as an `N`-dimensional array, maps a molecule count of zero to
+`offset`, and uses `perm` to map state-array dimensions to Catalyst's species order.
 
 The zero-argument constructor uses Julia's one-based indexing and preserves the
 species order. This representation is appropriate when every state in the truncated
@@ -77,7 +140,15 @@ DefaultIndexHandler{N}() where {N} = DefaultIndexHandler{N}(1, Tuple(1:N))
 """
     NaiveIndexHandler
 
-Deprecated alias for [`DefaultIndexHandler`](@ref). Use `DefaultIndexHandler` instead.
+Deprecated constructor forwarding to [`DefaultIndexHandler`](@ref).
+
+# Arguments
+- `args...`: Positional arguments accepted by `DefaultIndexHandler`.
+
+# Keyword Arguments
+- `kwargs...`: Keyword arguments accepted by `DefaultIndexHandler`.
+
+Use `DefaultIndexHandler` directly instead.
 """
 function NaiveIndexHandler(args...; kwargs...)
     Base.depwarn(
@@ -86,7 +157,6 @@ function NaiveIndexHandler(args...; kwargs...)
     )
     return DefaultIndexHandler(args...; kwargs...)
 end
-export NaiveIndexHandler
 
 Base.vec(::DefaultIndexHandler, arr) = vec(arr)
 Base.LinearIndices(::DefaultIndexHandler, arr) = LinearIndices(arr)

--- a/src/matrix.jl
+++ b/src/matrix.jl
@@ -78,10 +78,17 @@ end
 """
     SparseArrays.SparseMatrixCSC(sys::FSPSystem, dims::NTuple, ps, t::Real)
 
-Convert the reaction system into a sparse matrix defining the right-hand side of the
-Chemical Master Equation. `dims` is a tuple denoting the dimensions of the FSP and
-`ps` is the tuple of parameters. The sparse matrix works on the flattened version
-of the state obtained using `vec`.
+Converts an FSP system into a sparse matrix defining the time-dependent Chemical
+Master Equation.
+
+# Arguments
+- `sys`: FSP system to convert.
+- `dims`: Dimensions of the truncated FSP state array.
+- `pmap`: Iterable of parameter-value pairs, or `SciMLBase.NullParameters()`.
+- `t`: Time at which to evaluate a time-dependent rate law.
+
+# Returns
+- A sparse matrix acting on the state vector produced by [`vec`](@ref Base.vec).
 """
 function SparseArrays.SparseMatrixCSC(sys::FSPSystem, dims::NTuple, pmap, t::Real)
     return create_sparsematrix(sys, dims, pmap_to_p(sys, pmap), t)
@@ -90,8 +97,18 @@ end
 """
     SparseArrays.SparseMatrixCSC(sys::FSPSystem, dims::NTuple, ps, ::SteadyState)
 
-Convert the reaction system into a sparse matrix defining the right-hand side of the
-Chemical Master Equation, steady-state version.
+Converts an FSP system into the sparse matrix for its steady-state Chemical Master
+Equation formulation.
+
+# Arguments
+- `sys`: FSP system to convert.
+- `dims`: Dimensions of the truncated FSP state array.
+- `pmap`: Iterable of parameter-value pairs, or `SciMLBase.NullParameters()`.
+- `SteadyState()`: Dispatch marker selecting the formulation that drops transitions
+  leaving the truncated state space.
+
+# Returns
+- A sparse matrix acting on the state vector produced by [`vec`](@ref Base.vec).
 """
 function SparseArrays.SparseMatrixCSC(sys::FSPSystem, dims::NTuple, pmap, ::SteadyState)
     return create_sparsematrix_ss(sys, dims, pmap_to_p(sys, pmap))

--- a/test/indexhandler_interface.jl
+++ b/test/indexhandler_interface.jl
@@ -1,0 +1,55 @@
+using Test
+using Catalyst: @reaction_network
+using FiniteStateProjection: AbstractIndexHandler, DefaultIndexHandler, FSPSystem
+import FiniteStateProjection:
+    build_rhs_header, getsubstitutions, pairedindices, singleindices
+using SciMLBase: ODEProblem
+import Base: LinearIndices, vec
+import SparseArrays: SparseMatrixCSC
+
+struct DelegatingIndexHandler{N} <: AbstractIndexHandler
+    delegate::DefaultIndexHandler{N}
+end
+
+DelegatingIndexHandler{N}() where {N} = DelegatingIndexHandler(DefaultIndexHandler{N}())
+
+singleindices(ih::DelegatingIndexHandler, arr::AbstractArray) = singleindices(ih.delegate, arr)
+singleindices(ih::DelegatingIndexHandler, dims::Tuple) = singleindices(ih.delegate, dims)
+pairedindices(ih::DelegatingIndexHandler, arr::AbstractArray, shift::CartesianIndex) =
+    pairedindices(ih.delegate, arr, shift)
+pairedindices(ih::DelegatingIndexHandler, dims::Tuple, shift::CartesianIndex) =
+    pairedindices(ih.delegate, dims, shift)
+getsubstitutions(ih::DelegatingIndexHandler, rs; state_sym) =
+    getsubstitutions(ih.delegate, rs; state_sym)
+LinearIndices(ih::DelegatingIndexHandler, arr) = LinearIndices(ih.delegate, arr)
+vec(ih::DelegatingIndexHandler, arr) = vec(ih.delegate, arr)
+
+function build_rhs_header(::FSPSystem{<:DelegatingIndexHandler})
+    return quote
+        birth, death = p
+    end
+end
+
+@testset "Public index-handler interface" begin
+    rs = @reaction_network begin
+        birth, 0 --> X
+        death, X --> 0
+    end
+    pmap = [:birth => 2.0, :death => 1.0]
+    u0 = [1.0, 0.0, 0.0]
+
+    default_system = FSPSystem(rs)
+    custom_system = FSPSystem(rs, DelegatingIndexHandler{1}())
+
+    default_matrix = SparseMatrixCSC(default_system, size(u0), pmap, 0.0)
+    custom_matrix = SparseMatrixCSC(custom_system, size(u0), pmap, 0.0)
+    @test custom_matrix == default_matrix
+
+    default_problem = ODEProblem(default_system, u0, (0.0, 1.0), pmap)
+    custom_problem = ODEProblem(custom_system, u0, (0.0, 1.0), pmap)
+    default_du = similar(u0)
+    custom_du = similar(u0)
+    default_problem.f(default_du, u0, default_problem.p, 0.0)
+    custom_problem.f(custom_du, u0, custom_problem.p, 0.0)
+    @test custom_du == default_du
+end


### PR DESCRIPTION
## Summary
- document the complete public index-handler extension contract at definition sites
- render the user-facing extension API and add a generic external-handler regression test
- make the docs environment directly depend on FiniteStateProjection without source-path metadata

## Verification
- `Pkg.test()` (49/49)
- strict `run_qa(FiniteStateProjection)` (20/20)
- `docs/make.jl` with doctests, document checks, and HTML rendering
- Runic docstring check and `git diff --check`

Ignore until reviewed by @ChrisRackauckas.