### PR TITLE
Restore the documented model-definition surface as explicit exports

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.4.2"
 
 [deps]
 Catalyst = "479239e8-5488-4da2-87a7-35f2df7eef83"
+CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"
 ModelingToolkitBase = "7771a370-6774-4173-bd38-47e70ca0b839"
 PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 RuntimeGeneratedFunctions = "7e49a35a-f44a-4d26-94aa-eba1b4ca6b47"
@@ -16,6 +17,7 @@ SymbolicUtils = "d1185830-fcd6-423d-90d6-eec64667417b"
 
 [compat]
 Catalyst = "16.2"
+CommonSolve = "0.2.4"
 Distributions = "0.25"
 LinearAlgebra = "1"
 ModelingToolkitBase = "1.17"

--- a/docs/src/mainapi.md
+++ b/docs/src/mainapi.md
@@ -30,3 +30,48 @@ SteadyState
 Base.convert(::Type{ODEFunction}, ::FSPSystem, ::SteadyState)
 SciMLBase.SteadyStateProblem(::FSPSystem, u0, p)
 ```
+
+## Reexported model-definition and problem interface
+
+The documented workflow starts from a [Catalyst](https://docs.sciml.ai/Catalyst/stable/)
+reaction network and ends in a SciML problem:
+
+```julia
+using FiniteStateProjection
+using OrdinaryDiffEq
+
+rn = @reaction_network begin
+    σ, 0 --> A
+    d, A --> 0
+end
+
+sys = FSPSystem(rn)
+prob = ODEProblem(sys, u0, (0, 10.0), ps)
+sol = solve(prob, Vern7())
+```
+
+`using FiniteStateProjection` brings the names that workflow touches into scope.
+FiniteStateProjection only reexports them — they are owned and documented
+upstream, at the links below.
+
+  - Defining and inspecting the reaction network, owned by
+    [Catalyst](https://docs.sciml.ai/Catalyst/stable/): `@reaction_network`,
+    `ReactionSystem` (the type [`FSPSystem`](@ref) wraps), and the accessors
+    `species`, `numspecies` and `reactions`, which give the number and order of
+    the state-space dimensions a truncation has to cover
+  - Building the problem, owned by
+    [SciMLBase](https://docs.sciml.ai/SciMLBase/stable/) and
+    [CommonSolve](https://github.com/SciML/CommonSolve.jl): `ODEProblem`,
+    `SteadyStateProblem`, `ODEFunction`, `solve`. FiniteStateProjection defines
+    the `FSPSystem` methods of the first three, documented above.
+
+Anything else from Catalyst must be imported from Catalyst directly. In
+particular, FiniteStateProjection does not reexport Catalyst's symbolic
+model-building surface (`@species`, `@parameters`, `@variables`, `@reaction`,
+`Reaction`, network-composition and analysis functions), nor the other problem
+types Catalyst exposes (`SDEProblem`, `JumpProblem`, `DiscreteProblem`), none of
+which the finite state projection uses. Solver algorithms are not reexported
+either — `solve(prob, Vern7())` still needs
+[OrdinaryDiffEq](https://docs.sciml.ai/DiffEqDocs/stable/), and
+`SparseMatrixCSC` for the [matrix conversions](@ref matrix_conversions) comes
+from the `SparseArrays` standard library.

--- a/src/FiniteStateProjection.jl
+++ b/src/FiniteStateProjection.jl
@@ -17,10 +17,36 @@ using SymbolicUtils: substitute
 
 import Base: LinearIndices, vec
 
+# ---------------------------------------------------------------------------
+# Reexported interface (see the second `export` block below).
+#
+# The documented entry point of this package is a Catalyst reaction network:
+#
+#     rn = @reaction_network begin
+#         σ, 0 --> A
+#         d, A --> 0
+#     end
+#     sys = FSPSystem(rn)
+#     prob = ODEProblem(sys, u0, (0, 10.0), ps)
+#
+# `@reaction_network` and the problem constructors reached the user through
+# `@reexport using Catalyst`, so `using FiniteStateProjection` was enough to write
+# that. The blanket reexport (441 names, most of them Catalyst's symbolic and
+# modelling stack) is gone; this is the subset that normal documented use needs,
+# each imported from the module that owns it and documented there.
+# ---------------------------------------------------------------------------
+using Catalyst: @reaction_network
+using CommonSolve: solve
+
 RuntimeGeneratedFunctions.init(@__MODULE__)
 
 export AbstractIndexHandler, DefaultIndexHandler, FSPSystem, NaiveIndexHandler, SteadyState,
     build_rhs_header, getsubstitutions, pairedindices, singleindices
+
+# Reexported model-definition and problem interface; approved via `reexports_allow`
+# in test/qa/qa.jl and documented in docs/src/mainapi.md.
+export @reaction_network, ReactionSystem, numspecies, reactions, species
+export ODEFunction, ODEProblem, SteadyStateProblem, solve
 
 _unresolve1(x) = x
 _unresolve1(f::Function) = nameof(f)

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,3 +1,30 @@
-using SciMLTesting, FiniteStateProjection
+using SciMLTesting, FiniteStateProjection, Test
 
-run_qa(FiniteStateProjection)
+# The model-definition and problem interface FiniteStateProjection deliberately
+# reexports so that `using FiniteStateProjection` on its own is enough to write the
+# documented workflow: build a reaction network with `@reaction_network`, wrap it in
+# an `FSPSystem`, and turn that into an `ODEProblem` or `SteadyStateProblem`. Owned
+# and documented upstream; kept in sync with the reexport `export` block in
+# src/FiniteStateProjection.jl and the "Reexported model-definition and problem
+# interface" section of docs/src/mainapi.md.
+const REEXPORTS = (
+    # Defining and inspecting the reaction network (Catalyst).
+    Symbol("@reaction_network"), :ReactionSystem, :numspecies, :reactions, :species,
+    # Building the problem; FiniteStateProjection defines the `FSPSystem` methods of
+    # `ODEProblem`, `SteadyStateProblem` and the `ODEFunction` conversion.
+    :ODEFunction, :ODEProblem, :SteadyStateProblem, :solve,
+)
+
+run_qa(FiniteStateProjection; reexports_allow = REEXPORTS)
+
+@testset "Reexport surface" begin
+    # Every approved reexport must actually be reachable from `using
+    # FiniteStateProjection`, so the allow-list cannot drift into approving names the
+    # package no longer provides. `isdefined(@__MODULE__, ...)` tests the property
+    # directly: this file's `using FiniteStateProjection` is what has to bring the name
+    # into scope.
+    @testset "$name" for name in REEXPORTS
+        @test name in names(FiniteStateProjection)
+        @test isdefined(@__MODULE__, name)
+    end
+end


### PR DESCRIPTION
## What broke

`Document public API and migrate QA to SciMLTesting 2.4 (#70)` (5c031a1) removed `@reexport using Catalyst`.

The brief for this sweep asked me to check whether the docs examples had *always* done `using Catalyst` explicitly — if so, the reexport would have been genuinely redundant and no fix would be needed. They had not. The same commit that removed the reexport had to **add** `using Catalyst` to:

- `README.md` (both examples)
- `docs/src/examples.md` (both examples)
- `docs/src/troubleshoot.md`
- `test/birthdeath2D.jl`, `test/feedbackloop.jl`, `test/telegraph.jl`

That is direct evidence that `@reaction_network` — the first line of every documented example — used to come from `using FiniteStateProjection`. The SciMLBase problem constructors this package defines `FSPSystem` methods on were in scope through the same chain, since Catalyst reexports `ODEProblem`, `SteadyStateProblem`, `ODEFunction` and `solve`.

**One honest caveat, and the reason this is the mildest of the three cases in this sweep:** unlike NBodySimulator (1.14 → 1.15) and ParameterizedFunctions (5.24.3 → 5.25.0), this strip shipped as 0.3.6 → **0.4.0**, which *is* the breaking bump for a 0.x package. Downstream packages with `FiniteStateProjection = "0.3"` were therefore not silently broken, and the docs were kept self-consistent. What remains is that the package's public surface went from "whole dependency" straight to "nothing", skipping the curated middle the rule asks for, and that user code and tutorials written against 0.3 break with `UndefVarError: @reaction_network` rather than with a resolver message.

## The fix

Follow SciML/Sundials.jl#553: not the blanket `@reexport using Dep`, and not a stripped surface — an explicit `export` list of exactly what normal documented use needs. **Nine names, out of the 441 that `using Catalyst` provides.**

| role | names | owner |
|---|---|---|
| Defining and inspecting the reaction network | `@reaction_network`, `ReactionSystem`, `species`, `numspecies`, `reactions` | Catalyst |
| Building the problem | `ODEProblem`, `SteadyStateProblem`, `ODEFunction`, `solve` | SciMLBase, CommonSolve |

Evidence for each group:

1. **`@reaction_network`** — line 1 of every example in `README.md` and `docs/src/examples.md`, and the entry point `FSPSystem` is documented to take.
2. **`ReactionSystem`** — the type `FSPSystem` wraps (`docs/src/mainapi.md`: *"a thin wrapper around Catalyst's `ReactionSystem`"*), named in `docs/src/index.md`, and used in the rendered `getsubstitutions(::DefaultIndexHandler, ::ReactionSystem)` signature in `docs/src/internal.md`.
3. **`species`, `numspecies`, `reactions`** — the accessors that give the number and order of state-space dimensions a truncation has to cover, which is precisely what `docs/src/troubleshoot.md` ("Ensure your state space has the right dimension") is about.
4. **`ODEProblem`, `SteadyStateProblem`, `ODEFunction`** — FiniteStateProjection defines the `FSPSystem` methods of all three, and they are the rendered API on `docs/src/mainapi.md`. Exporting the constructors a package defines methods on is exactly the Sundials pattern.
5. **`solve`** — the closing line of every documented example.

**Deliberately not restored:** Catalyst's symbolic model-building surface (`@species`, `@parameters`, `@variables`, `@reaction`, `Reaction`, composition and network-analysis functions), and the problem types the FSP does not use (`SDEProblem`, `JumpProblem`, `DiscreteProblem`). Solver algorithms were never reexported and still are not — `solve(prob, Vern7())` needs OrdinaryDiffEq, as the examples show. `SparseMatrixCSC` for the matrix conversions still comes from the `SparseArrays` stdlib; it was never exported here either.

`solve` is imported from CommonSolve, its owner (new direct dependency; a dependency-free 3-function package already deep in the graph), so ExplicitImports' owner checks stay clean with no ignore-lists.

## Documentation

`docs/src/mainapi.md` gains a **Reexported model-definition and problem interface** section: a worked example, the names grouped by role with the upstream owner named and linked per group, and an explicit boundary line — anything else from Catalyst must be imported from Catalyst directly — with the exclusions above called out and explained.

## Drift protection

`test/qa/qa.jl` declares the same list through `reexports_allow` and adds a testset asserting every approved name is in `names(FiniteStateProjection)` **and** actually in scope from `using FiniteStateProjection`. The docs list, the `export` block and the `REEXPORTS` tuple are now the same list in three places.

## Semver

Restoring names that were exported through 0.3.6 is **not breaking**. No version bump in this PR; a separate release pass handles versions.

## Verification run locally (Julia 1.11.8, macOS aarch64)

- `run_qa(FiniteStateProjection; reexports_allow = REEXPORTS)` — 20/20 pass; the new `Reexport surface` testset — 18/18 pass.
- `Pkg.test()` (Core group) — all five files pass: `birthdeath2D.jl` 18/18, `feedbackloop.jl` 12/12, `indexhandler_interface.jl` 2/2, `symbolic_api.jl` 11/11, `telegraph.jl` 17/17.
- The README birth-death example from a bare `using FiniteStateProjection`: `@reaction_network` parses, `rn isa ReactionSystem` is true, `numspecies`/`species`/`reactions` resolve, and `ODEProblem`, `SteadyStateProblem` and `convert(ODEFunction, sys)` all construct.

Not verified: a full `Documenter` build of the edited page (not run here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rmh6B9eoW3N8oCbuuVPVxJ