### PR TITLE
Bump version to 0.4.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FiniteStateProjection"
 uuid = "069e79ea-d681-44e8-b935-95bdaf9e8f28"
 authors = ["kaandocal"]
-version = "0.4.2"
+version = "0.4.3"
 
 [deps]
 Catalyst = "479239e8-5488-4da2-87a7-35f2df7eef83"


### PR DESCRIPTION
## What changed and why

Bumps FiniteStateProjection from 0.4.2 to 0.4.3 to release the restored, explicitly documented model-definition surface from https://github.com/SciML/FiniteStateProjection.jl/pull/81. This is the next consecutive version and follows the patch-bump policy for restored public API in a 0.x package.

Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Verification

- `~/.juliaup/bin/julia +release -m Runic --check .` — exited 0.
- `typos Project.toml` — exited 0 with no findings.
- `GROUP=QA ~/.juliaup/bin/julia +release --project -e 'using Pkg; Pkg.test()'` — `QA/qa.jl | 38 passed / 38 total`; package tests passed.
- `~/.juliaup/bin/julia +release --project -e 'using Pkg; Pkg.test()'` — five Core testsets, 60 passed / 60 total; package tests passed.

## Not verified

The docs build and downstream/allowed-to-fail jobs were not run locally because this PR changes only the package version.

AI continuation: OpenAI Codex session ID 01a03a11-47c2-77e0-858b-167004f0b79c.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rmh6B9eoW3N8oCbuuVPVxJ