### PR TITLE
Format for Runic v1.10

### DIFF
--- a/src/indexhandlers.jl
+++ b/src/indexhandlers.jl
@@ -195,9 +195,9 @@ function pairedindices(
     ranges = tuple(
         (
             UnitRange(
-                    max(first(ax), first(ax) + shift[ih.perm[i]]),
-                    min(last(ax), last(ax) + shift[ih.perm[i]])
-                )
+                max(first(ax), first(ax) + shift[ih.perm[i]]),
+                min(last(ax), last(ax) + shift[ih.perm[i]])
+            )
                 for (i, ax) in enumerate(dims)
         )...
     )


### PR DESCRIPTION
## What changed and why

Runic v1.10.0 changed multiline-generator indentation. This PR applies the formatter output required by that release in `src/indexhandlers.jl`; it contains no behavioral, dependency, documentation, or public-API changes.

**Ignore this PR until it has been reviewed by @ChrisRackauckas.**

## Verification

Failing before formatting at `ff99707383cd9e8352dce1bb8c76e3de24021f56`:

```console
$ ~/.juliaup/bin/julia +release --startup-file=no --project=@runic -m Runic --check .
[exit 1]
```

Passing after formatting:

```console
$ ~/.juliaup/bin/julia +release --startup-file=no --project=@runic -m Runic --check .
[exit 0]
$ git diff --check
[exit 0]
$ typos src/indexhandlers.jl
[exit 0]
$ GROUP=QA ~/.juliaup/bin/julia +release --startup-file=no --project -e 'using Pkg; Pkg.test()'
QA/qa.jl | 38 pass, 38 total
Testing FiniteStateProjection tests passed
$ GROUP=All ~/.juliaup/bin/julia +release --startup-file=no --project -e 'using Pkg; Pkg.test()'
Core/birthdeath2D.jl             | 18 pass, 18 total
Core/feedbackloop.jl             | 12 pass, 12 total
Core/indexhandler_interface.jl   |  2 pass,  2 total
Core/symbolic_api.jl             | 11 pass, 11 total
Core/telegraph.jl                | 17 pass, 17 total
Testing FiniteStateProjection tests passed
```

## Not verified

- GPU, downstream, and allowed-to-fail jobs were not run locally.
- Documentation was not built because this formatter-only change does not touch docs, docstrings, or public API.

## Reviewer note

This is a mechanical Runic-only indentation change inside a multiline generator.

🤖 Generated with Codex CLI 0.151.0 (model: unknown; session: local session ID 01a04fa1-cfe0-7260-b416-72fe8a15d17d)
