### PR TITLE
Update Symbolics compat-floor test to 7.39.2

### DIFF
--- a/test/symbolic_api.jl
+++ b/test/symbolic_api.jl
@@ -17,7 +17,7 @@ using TOML
     @test compat["ModelingToolkitBase"] == "1.17"
     @test compat["SciMLBase"] == "3"
     @test compat["SymbolicIndexingInterface"] == "0.3.43"
-    @test compat["Symbolics"] == "7.13"
+    @test compat["Symbolics"] == "7.39.2"
     @test compat["SymbolicUtils"] == "4.18"
 
     rs = @reaction_network begin


### PR DESCRIPTION
## Summary

`test/symbolic_api.jl` asserts `compat["Symbolics"] == "7.13"`, but `Project.toml` was bumped to `Symbolics = "7.39.2"` in #87 (32-bit hash fix). The stale assertion fails on every non-x86 lane (`10 passed, 1 failed`).

Note: the separate `N_VMake_Serial(::Int32, ::Vector{Float64}, ::Ptr{Nothing})` precompile failure on the x86 lane is an upstream Sundials.jl 32-bit issue, not addressed here.

#### Test plan
- [x] Verified `TOML.parsefile("Project.toml")["compat"]["Symbolics"] == "7.39.2"` matches the updated assertion

🤖 Generated with Devin CLI (model: SWE-2 Max) — local session, no shareable URL