### PR TITLE
Add AirspeedVelocity benchmarking CI

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,29 @@
+name: Benchmark this PR
+
+on:
+  pull_request:
+    branches: [main]
+    paths-ignore: ['docs/**']
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ["1", "lts"]
+    env:
+      # Force consistent Julia depot path for self-hosted runners
+      JULIA_DEPOT_PATH: ~/.julia
+    steps:
+      - uses: MilesCranmer/AirspeedVelocity.jl@action-v1
+        with:
+          julia-version: ${{ matrix.version }}
+          script: "benchmark/benchmarks.jl"
+          extra-pkgs: "Catalyst,OrdinaryDiffEqVerner"
+          job-summary: true

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,0 +1,46 @@
+using FiniteStateProjection, BenchmarkTools
+using Catalyst
+using OrdinaryDiffEqVerner: Vern7
+using SparseArrays, LinearAlgebra
+
+const SUITE = BenchmarkGroup()
+
+rs = @reaction_network begin
+    r1, 0 --> A
+    r2, A --> 0
+    s1, 0 --> B
+    s2, B --> 0
+end
+
+pmap = [:r1 => 2.0, :r2 => 1.3, :s1 => 1.7, :s2 => 0.8]
+Nmax = 45
+u0 = zeros(Nmax + 1, Nmax + 1)
+u0[1] = 1.0
+
+# =============================================================================
+# FSPSystem + sparse operator construction
+# =============================================================================
+
+SUITE["construct"] = BenchmarkGroup()
+
+SUITE["construct"]["FSPSystem"] = @benchmarkable FSPSystem($rs)
+sys = FSPSystem(rs)
+SUITE["construct"]["sparse_A"] = @benchmarkable SparseMatrixCSC(
+    $sys, ($Nmax + 1, $Nmax + 1), $pmap, 0
+)
+
+# =============================================================================
+# FSP ODE problem + solve
+# =============================================================================
+
+SUITE["solve"] = BenchmarkGroup()
+
+SUITE["solve"]["ode_problem"] = @benchmarkable ODEProblem(
+    $sys, $u0, 10.0, $pmap
+)
+
+prob = ODEProblem(sys, u0, 10.0, pmap)
+
+SUITE["solve"]["vern7"] = @benchmarkable solve(
+    $prob, Vern7(); abstol = 1.0e-6, saveat = [0.25, 1.0, 10.0]
+)


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/benchmark.yml` running AirspeedVelocity on pull requests (Julia `1` and `lts`, 30 min timeout), following the OrdinaryDiffEq.jl setup.
- Adds `benchmark/benchmarks.jl` with a small `SUITE` covering representative workloads for this package.

The suite was verified locally in a fresh environment: it loads and all benchmarks run in ~42s.

#### Test plan

- [x] `run(SUITE)` locally: all benchmarks pass (~42s)
- [x] Runic formatting clean on `benchmark/benchmarks.jl`
- [ ] \"Benchmark this PR\" workflow triggers and completes on this PR

🤖 Generated with [Devin](https://devin.ai) (harness: devin 3000.10.21, model: SWE-2 Max)
Session: local transcript /home/crackauc/.local/share/devin/cli/summaries/history_ccb52064e6514b21.md